### PR TITLE
Add custom authentication request filter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
     * Requests to the extension are now intercepted by a request filter
     * Requests to all endpoints except /api/selfDescription require authentication
     * The authentication method is defined within the launcher's build file. In the example launcher, a mocked identity and access management service is used: _org.eclipse.dataspaceconnector:iam-mock_
+    * Available authentication methods are defined by the EDC. For further information see the EDC's AuthenticationServices and AuthenticationRequestFilters.
 
 * Configuration value "exposeSelfDescription"
     * Set to _False_ to not expose the extension's self descriptions

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@
 
 **New Features**
 
+* Custom AuthenticationRequestFilter
+    * Requests to the extension are now intercepted by a request filter
+    * Requests to all endpoints except /api/selfDescription require authentication
+    * The authentication method is defined within the launcher's build file. In the example launcher, a mocked identity and access management service is used: _org.eclipse.dataspaceconnector:iam-mock_
+
 * Configuration value "exposeSelfDescription"
     * Set to _False_ to not expose the extension's self descriptions
     * Default value is _True_

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/AasExtension.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/AasExtension.java
@@ -101,6 +101,7 @@ public class AasExtension implements ServiceExtension {
                 configInstance.getSyncPeriod(), TimeUnit.SECONDS);
 
         webService.registerResource(endpoint);
+        webService.registerResource(new CustomAuthenticationRequestFilter(authenticationService));
     }
 
     /**

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/CustomAuthenticationRequestFilter.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/CustomAuthenticationRequestFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.app;
+
+import org.eclipse.dataspaceconnector.api.auth.AuthenticationRequestFilter;
+import org.eclipse.dataspaceconnector.api.auth.AuthenticationService;
+
+import de.fraunhofer.iosb.app.model.configuration.Configuration;
+import jakarta.ws.rs.container.ContainerRequestContext;
+
+/**
+ * Custom AuthenticationRequestFilter filtering requests that go directly to an
+ * AAS service (managed by this extension).
+ */
+public class CustomAuthenticationRequestFilter extends AuthenticationRequestFilter {
+
+    private final Configuration config;
+    private static final String selfDescriptionEndpointName = "selfDescription";
+
+    public CustomAuthenticationRequestFilter(AuthenticationService authenticationService) {
+        super(authenticationService);
+        config = Configuration.getInstance();
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        // SelfDescription request?
+        if (requestContext.getUriInfo().getPath().equals(selfDescriptionEndpointName)
+                && config.isExposeSelfDescription()) {
+            Logger.getInstance().debug("CustomAuthenticationRequestFilter: Not intercepting this request");
+            return;
+        }
+        Logger.getInstance().debug("CustomAuthenticationRequestFilter: Intercepting this request");
+        super.filter(requestContext);
+    }
+}

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/CustomAuthenticationRequestFilter.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/CustomAuthenticationRequestFilter.java
@@ -23,12 +23,11 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 
 /**
  * Custom AuthenticationRequestFilter filtering requests that go directly to an
- * AAS service (managed by this extension).
+ * AAS service (managed by this extension) or the extension's configuration.
  */
 public class CustomAuthenticationRequestFilter extends AuthenticationRequestFilter {
 
     private final Configuration config;
-    private static final String selfDescriptionEndpointName = "selfDescription";
 
     public CustomAuthenticationRequestFilter(AuthenticationService authenticationService) {
         super(authenticationService);
@@ -37,13 +36,12 @@ public class CustomAuthenticationRequestFilter extends AuthenticationRequestFilt
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        // SelfDescription request?
-        if (requestContext.getUriInfo().getPath().equals(selfDescriptionEndpointName)
+        if (!Endpoint.SELF_DESCRIPTION_PATH.equalsIgnoreCase(requestContext.getUriInfo().getPath())
                 && config.isExposeSelfDescription()) {
+            Logger.getInstance().debug("CustomAuthenticationRequestFilter: Intercepting this request");
+            super.filter(requestContext);
+        } else {
             Logger.getInstance().debug("CustomAuthenticationRequestFilter: Not intercepting this request");
-            return;
         }
-        Logger.getInstance().debug("CustomAuthenticationRequestFilter: Intercepting this request");
-        super.filter(requestContext);
     }
 }

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/Endpoint.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/Endpoint.java
@@ -60,8 +60,13 @@ import static java.lang.String.format;
 @Path("/")
 public class Endpoint {
 
-    public static final String AAS_REQUEST_PATH = "aas";
+    public static final String SELF_DESCRIPTION_PATH = "selfDescription";
 
+    private static final String AAS_REQUEST_PATH = "aas";
+    private static final String CONFIG_PATH = "config";
+    private static final String CLIENT_PATH = "client";
+    private static final String ENVIRONMENT_PATH = "environment";
+    
     private final ConfigurationController configurationController;
     private final AasController aasController;
     private final ResourceController resourceController;
@@ -98,7 +103,7 @@ public class Endpoint {
      * @return Current configuration values
      */
     @GET
-    @Path("config")
+    @Path(CONFIG_PATH)
     public Response getConfig() {
         logger.debug("Received a config GET request");
         return configurationController.handleRequest(RequestType.GET, null);
@@ -111,7 +116,7 @@ public class Endpoint {
      * @return Response with status code
      */
     @PUT
-    @Path("config")
+    @Path(CONFIG_PATH)
     public Response putConfig(@Nonnull String newConfigurationJson) {
         logger.debug("Received a config PUT request");
         Objects.requireNonNull(newConfigurationJson);
@@ -125,7 +130,7 @@ public class Endpoint {
      * @return Response
      */
     @POST
-    @Path("client")
+    @Path(CLIENT_PATH)
     public Response postAasService(@QueryParam("url") URL aasServiceUrl) {
         logger.log("Received a client POST request");
         Objects.requireNonNull(aasServiceUrl);
@@ -166,7 +171,7 @@ public class Endpoint {
      * @return Response containing new AAS URL or error code
      */
     @POST
-    @Path("environment")
+    @Path(ENVIRONMENT_PATH)
     public Response postAasEnvironment(@QueryParam("environment") String pathToEnvironment,
             @QueryParam("config") String pathToAssetAdministrationShellConfig, @QueryParam("port") int port) {
         logger.log("Received an environment POST request");
@@ -212,7 +217,7 @@ public class Endpoint {
      * @return Response "ok" containing status message
      */
     @DELETE
-    @Path("client")
+    @Path(CLIENT_PATH)
     public Response removeAasService(@QueryParam("url") @Nonnull URL aasServiceUrl) {
         logger.log("Received a client DELETE request");
         Objects.requireNonNull(aasServiceUrl);
@@ -352,7 +357,7 @@ public class Endpoint {
      * @return Self description(s)
      */
     @GET
-    @Path("selfDescription")
+    @Path(SELF_DESCRIPTION_PATH)
     public Response getSelfDescription(@QueryParam("aasService") URL aasServiceUrl) {
         if (Objects.isNull(aasServiceUrl)) {
             logger.debug("Received a self description GET request");

--- a/edc-extension4aas/src/test/java/de/fraunhofer/iosb/app/CustomAuthenticationRequestFilterTest.java
+++ b/edc-extension4aas/src/test/java/de/fraunhofer/iosb/app/CustomAuthenticationRequestFilterTest.java
@@ -1,0 +1,85 @@
+package de.fraunhofer.iosb.app;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.dataspaceconnector.api.auth.AuthenticationService;
+import org.eclipse.dataspaceconnector.spi.exception.AuthenticationFailedException;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import de.fraunhofer.iosb.app.model.configuration.Configuration;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+
+public class CustomAuthenticationRequestFilterTest {
+
+    AuthenticationService authService = mock(AuthenticationService.class);
+    CustomAuthenticationRequestFilter authRequestFilter = new CustomAuthenticationRequestFilter(authService);
+
+    @BeforeAll
+    public static void initializeLogger() {
+        Logger.getInstance().setMonitor(mock(Monitor.class));
+    }
+
+    @Test
+    void filterSelfDescriptionTest() {
+        verify(authService, times(0)).isAuthenticated(any());
+        setupConfigExposeSelfDescriptionValue(true);
+        var mockedContext = createSemiAuthenticRequestContext(Endpoint.SELF_DESCRIPTION_PATH, false);
+        authRequestFilter.filter(mockedContext);
+    }
+
+    @Test
+    void filterRequestUnauthenticatedTest() {
+        setupConfigExposeSelfDescriptionValue(true);
+        var mockedContext = createSemiAuthenticRequestContext("config", false);
+
+        try {
+            authRequestFilter.filter(mockedContext);
+            fail();
+        } catch (AuthenticationFailedException expected) {
+        }
+    }
+
+    @Test
+    void filterRequestAuthenticatedTest() {
+        setupConfigExposeSelfDescriptionValue(true);
+        var mockedContext = createSemiAuthenticRequestContext("unauthorizedPath", true);
+        authRequestFilter.filter(mockedContext);
+    }
+
+    private void setupConfigExposeSelfDescriptionValue(boolean expose) {
+        Configuration conf = Configuration.getInstance();
+        conf.setExposeSelfDescription(expose);
+    }
+
+    /*
+     * Just enough parameters are mocked so that the super class filter method does
+     * not crash
+     */
+    private ContainerRequestContext createSemiAuthenticRequestContext(String returnedPath,
+            boolean isAuthenticatedMockResponse) {
+        ContainerRequestContext mockedContainerRequestContext = mock(ContainerRequestContext.class);
+        UriInfo mockedUriInfo = mock(UriInfo.class);
+        when(mockedUriInfo.getPath()).thenReturn(returnedPath);
+
+        when(mockedContainerRequestContext.getUriInfo()).thenReturn(mockedUriInfo);
+
+        // Super class needs these to not crash
+        when(mockedContainerRequestContext.getHeaders()).thenReturn(new MultivaluedHashMap<String, String>());
+        when(mockedContainerRequestContext.getMethod()).thenReturn("POST");
+        setAuthenticatedBySuperclass(isAuthenticatedMockResponse);
+        return mockedContainerRequestContext;
+    }
+
+    private void setAuthenticatedBySuperclass(boolean authenticated) {
+        when(authService.isAuthenticated(any())).thenReturn(authenticated);
+    }
+}

--- a/example/resources/aas_edc_extension.postman_collection.json
+++ b/example/resources/aas_edc_extension.postman_collection.json
@@ -37,7 +37,13 @@
 					"name": "Add AAS service by file",
 					"request": {
 						"method": "POST",
-						"header": [],
+						"header": [
+							{
+								"key": "x-api-key",
+								"value": "password",
+								"type": "default"
+							}
+						],
 						"url": {
 							"raw": "{{provider-connector-url}}/api/environment?environment=path/to/edc-aas-extension/extensions/ids-aas-extension/src/test/AASModels/FestoDemoAAS.json&port=12345",
 							"host": [
@@ -67,7 +73,13 @@
 					"name": "Remove AAS service",
 					"request": {
 						"method": "DELETE",
-						"header": [],
+						"header": [
+							{
+								"key": "x-api-key",
+								"value": "password",
+								"type": "default"
+							}
+						],
 						"url": {
 							"raw": "{{provider-connector-url}}/api/client?url=http://localhost:12345",
 							"host": [
@@ -104,6 +116,84 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Forward DELETE to AAS service",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-api-key",
+								"value": "password",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "\"test\"",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{provider-connector-url}}/api/aas?requestUrl=http://localhost:12345/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvc20vMTE0NV84MDkwXzYwMTJfNTA5Nw",
+							"host": [
+								"{{provider-connector-url}}"
+							],
+							"path": [
+								"api",
+								"aas"
+							],
+							"query": [
+								{
+									"key": "requestUrl",
+									"value": "http://localhost:12345/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvc20vMTE0NV84MDkwXzYwMTJfNTA5Nw"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Forward PUT to AAS service",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-api-key",
+								"value": "password",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"modelType\": {\r\n        \"name\": \"Submodel\"\r\n    },\r\n    \"kind\": \"Instance\",\r\n    \"semanticId\": {\r\n        \"keys\": [\r\n            {\r\n                \"idType\": \"Iri\",\r\n                \"type\": \"GlobalReference\",\r\n                \"value\": \"0173-1#02-AAO677#002\"\r\n            }\r\n        ]\r\n    },\r\n    \"identification\": {\r\n        \"idType\": \"Iri\",\r\n        \"id\": \"https://example.com/ids/sm/4445_8090_6012_7409\"\r\n    },\r\n    \"idShort\": \"Status\",\r\n    \"submodelElements\": []\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{provider-connector-url}}/api/aas?requestUrl=http://localhost:12345/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvc20vNDQ0NV84MDkwXzYwMTJfNzQwOQ",
+							"host": [
+								"{{provider-connector-url}}"
+							],
+							"path": [
+								"api",
+								"aas"
+							],
+							"query": [
+								{
+									"key": "requestUrl",
+									"value": "http://localhost:12345/submodels/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvc20vNDQ0NV84MDkwXzYwMTJfNzQwOQ"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -128,7 +218,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"connectorId\": \"provider\",\r\n    \"connectorAddress\": \"{{provider-connector-ids-url}}\",\r\n    \"protocol\": \"ids-multipart\",\r\n    \"offer\": {\r\n        \"offerId\": \"{{contract-id}}:3a75736e-001d-4364-8bd4-9888490edb57\",\r\n        \"assetId\": \"{{asset-id}}\",\r\n        \"policy\": {\r\n            \"uid\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\r\n            \"permissions\": [\r\n                {\r\n                    \"edctype\": \"dataspaceconnector:permission\",\r\n                    \"uid\": null,\r\n                    \"target\": \"{{asset-id}}\",\r\n                    \"action\": {\r\n                        \"type\": \"USE\",\r\n                        \"includedIn\": null,\r\n                        \"constraint\": null\r\n                    },\r\n                    \"assignee\": null,\r\n                    \"assigner\": null,\r\n                    \"constraints\": [],\r\n                    \"duties\": []\r\n                }\r\n            ],\r\n            \"prohibitions\": [],\r\n            \"obligations\": [],\r\n            \"extensibleProperties\": {},\r\n            \"inheritsFrom\": null,\r\n            \"assigner\": null,\r\n            \"assignee\": null,\r\n            \"target\": null,\r\n            \"@type\": {\r\n                \"@policytype\": \"set\"\r\n            }\r\n        },\r\n        \"asset\": {\r\n            \"properties\": {\r\n                \"ids:byteSize\": null,\r\n                \"asset:prop:id\": \"{{asset-id}}\",\r\n                \"ids:fileName\": null\r\n            }\r\n        }\r\n    }\r\n}",
+							"raw": "{\r\n    \"connectorId\": \"provider\",\r\n    \"connectorAddress\": \"{{provider-connector-ids-url}}\",\r\n    \"protocol\": \"ids-multipart\",\r\n    \"offer\": {\r\n        \"offerId\": \"{{contract-id}}:3a75736e-001d-4364-8bd4-9888490edb57\",\r\n        \"assetId\": \"{{asset-id}}\",\r\n        \"policy\": {\r\n            \"permissions\": [\r\n                {\r\n                    \"edctype\": \"dataspaceconnector:permission\",\r\n                    \"uid\": null,\r\n                    \"target\": \"{{asset-id}}\",\r\n                    \"action\": {\r\n                        \"type\": \"USE\",\r\n                        \"includedIn\": null,\r\n                        \"constraint\": null\r\n                    },\r\n                    \"assignee\": null,\r\n                    \"assigner\": null,\r\n                    \"constraints\": [],\r\n                    \"duties\": []\r\n                }\r\n            ],\r\n            \"prohibitions\": [],\r\n            \"obligations\": [],\r\n            \"extensibleProperties\": {},\r\n            \"inheritsFrom\": null,\r\n            \"assigner\": null,\r\n            \"assignee\": null,\r\n            \"target\": \"{{asset-id}}\",\r\n            \"@type\": {\r\n                \"@policytype\": \"set\"\r\n            }\r\n        },\r\n        \"asset\": {\r\n            \"properties\": {\r\n                \"ids:byteSize\": null,\r\n                \"asset:prop:id\": \"{{asset-id}}\",\r\n                \"ids:fileName\": null\r\n            }\r\n        }\r\n    }\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -198,7 +288,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"protocol\": \"ids-multipart\",\r\n  \"assetId\": \"{{asset-id}}\",\r\n  \"contractId\": \"{{agreement-id}}\",\r\n  \"dataDestination\": {\r\n    \"properties\": {\r\n      \"baseUrl\": \"{{consumer-connector-endpoint-url}}/api/receiveTransfer/test\",\r\n      \"type\": \"HttpData\"\r\n    }\r\n  },\r\n  \"transferType\": {\r\n    \"contentType\": \"application/json\",\r\n    \"isFinite\": true\r\n  },\r\n  \"managedResources\": false,\r\n  \"connectorAddress\": \"{{provider-connector-ids-url}}\",\r\n  \"connectorId\": \"consumer\"\r\n}",
+							"raw": "{\r\n  \"protocol\": \"ids-multipart\",\r\n  \"assetId\": \"{{asset-id}}\",\r\n  \"contractId\": \"{{agreement-id}}\",\r\n  \"dataDestination\": {\r\n    \"properties\": {\r\n      \"baseUrl\": \"{{consumer-connector-endpoint-url}}/api/receiveTransfer/test\",\r\n      \"type\": \"HttpData\",\r\n      \"authKey\":\"x-api-key\",\r\n      \"authCode\": \"password\"\r\n    }\r\n  },\r\n  \"transferType\": {\r\n    \"contentType\": \"application/json\",\r\n    \"isFinite\": true\r\n  },\r\n  \"managedResources\": false,\r\n  \"connectorAddress\": \"{{provider-connector-ids-url}}\",\r\n  \"connectorId\": \"consumer\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -243,7 +333,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"connectorId\": \"provider\",\r\n    \"connectorAddress\": \"{{docker-provider-connector-ids-url}}\",\r\n    \"protocol\": \"ids-multipart\",\r\n    \"offer\": {\r\n        \"offerId\": \"{{contract-id}}:3a75736e-001d-4364-8bd4-9888490edb57\",\r\n        \"assetId\": \"{{asset-id}}\",\r\n        \"policy\": {\r\n            \"uid\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\r\n            \"permissions\": [\r\n                {\r\n                    \"edctype\": \"dataspaceconnector:permission\",\r\n                    \"uid\": null,\r\n                    \"target\": \"{{asset-id}}\",\r\n                    \"action\": {\r\n                        \"type\": \"USE\",\r\n                        \"includedIn\": null,\r\n                        \"constraint\": null\r\n                    },\r\n                    \"assignee\": null,\r\n                    \"assigner\": null,\r\n                    \"constraints\": [],\r\n                    \"duties\": []\r\n                }\r\n            ],\r\n            \"prohibitions\": [],\r\n            \"obligations\": [],\r\n            \"extensibleProperties\": {},\r\n            \"inheritsFrom\": null,\r\n            \"assigner\": null,\r\n            \"assignee\": null,\r\n            \"target\": null,\r\n            \"@type\": {\r\n                \"@policytype\": \"set\"\r\n            }\r\n        },\r\n        \"asset\": {\r\n            \"properties\": {\r\n                \"ids:byteSize\": null,\r\n                \"asset:prop:id\": \"{{asset-id}}\",\r\n                \"ids:fileName\": null\r\n            }\r\n        }\r\n    }\r\n}",
+							"raw": "{\r\n    \"connectorId\": \"provider\",\r\n    \"connectorAddress\": \"{{docker-provider-connector-ids-url}}\",\r\n    \"protocol\": \"ids-multipart\",\r\n    \"offer\": {\r\n        \"offerId\": \"{{contract-id}}:3a75736e-001d-4364-8bd4-9888490edb57\",\r\n        \"assetId\": \"{{asset-id}}\",\r\n        \"policy\": {\r\n            \"permissions\": [\r\n                {\r\n                    \"edctype\": \"dataspaceconnector:permission\",\r\n                    \"uid\": null,\r\n                    \"target\": \"{{asset-id}}\",\r\n                    \"action\": {\r\n                        \"type\": \"USE\",\r\n                        \"includedIn\": null,\r\n                        \"constraint\": null\r\n                    },\r\n                    \"assignee\": null,\r\n                    \"assigner\": null,\r\n                    \"constraints\": [\r\n                        {\r\n                            \"edctype\": \"AtomicConstraint\",\r\n                            \"leftExpression\": {\r\n                                \"edctype\": \"dataspaceconnector:literalexpression\",\r\n                                \"value\": \"region\"\r\n                            },\r\n                            \"rightExpression\": {\r\n                                \"edctype\": \"dataspaceconnector:literalexpression\",\r\n                                \"value\": \"eu\"\r\n                            },\r\n                            \"operator\": \"EQ\"\r\n                        }\r\n                    ],\r\n                    \"duties\": []\r\n                }\r\n            ],\r\n            \"prohibitions\": [],\r\n            \"obligations\": [],\r\n            \"extensibleProperties\": {},\r\n            \"inheritsFrom\": null,\r\n            \"assigner\": null,\r\n            \"assignee\": null,\r\n            \"target\": \"{{asset-id}}\",\r\n            \"@type\": {\r\n                \"@policytype\": \"set\"\r\n            }\r\n        },\r\n        \"asset\": {\r\n            \"properties\": {\r\n                \"ids:byteSize\": null,\r\n                \"asset:prop:id\": \"{{asset-id}}\",\r\n                \"ids:fileName\": null\r\n            }\r\n        }\r\n    }\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -313,7 +403,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"protocol\": \"ids-multipart\",\r\n  \"assetId\": \"{{asset-id}}\",\r\n  \"contractId\": \"{{agreement-id}}\",\r\n  \"dataDestination\": {\r\n    \"properties\": {\r\n      \"baseUrl\": \"{{docker-consumer-connector-endpoint-url}}/api/receiveTransfer/test\",\r\n      \"type\": \"HttpData\"\r\n    }\r\n  },\r\n  \"transferType\": {\r\n    \"contentType\": \"application/json\",\r\n    \"isFinite\": true\r\n  },\r\n  \"managedResources\": false,\r\n  \"connectorAddress\": \"{{docker-provider-connector-ids-url}}\",\r\n  \"connectorId\": \"consumer\"\r\n}",
+							"raw": "{\r\n  \"protocol\": \"ids-multipart\",\r\n  \"assetId\": \"{{asset-id}}\",\r\n  \"contractId\": \"{{agreement-id}}\",\r\n  \"dataDestination\": {\r\n    \"properties\": {\r\n      \"baseUrl\": \"{{docker-consumer-connector-endpoint-url}}/api/receiveTransfer/test\",\r\n      \"type\": \"HttpData\",\r\n      \"authKey\":\"x-api-key\",\r\n      \"authCode\": \"password\"\r\n    }\r\n  },\r\n  \"transferType\": {\r\n    \"contentType\": \"application/json\",\r\n    \"isFinite\": true\r\n  },\r\n  \"managedResources\": false,\r\n  \"connectorAddress\": \"{{docker-provider-connector-ids-url}}\",\r\n  \"connectorId\": \"consumer\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -385,6 +475,73 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Post policydefinitions",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-api-key",
+								"value": "password",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n            \"permissions\": [\r\n                {\r\n                    \"edctype\": \"dataspaceconnector:permission\",\r\n                    \"uid\": null,\r\n                    \"target\": \"-1736407145\",\r\n                    \"action\": {\r\n                        \"type\": \"USE\",\r\n                        \"includedIn\": null,\r\n                        \"constraint\": null\r\n                    },\r\n                    \"assignee\": null,\r\n                    \"assigner\": null,\r\n                    \"constraints\": [\r\n                        {\r\n                            \"edctype\": \"AtomicConstraint\",\r\n                            \"leftExpression\": {\r\n                                \"edctype\": \"dataspaceconnector:literalexpression\",\r\n                                \"value\": \"region\"\r\n                            },\r\n                            \"rightExpression\": {\r\n                                \"edctype\": \"dataspaceconnector:literalexpression\",\r\n                                \"value\": \"eu\"\r\n                            },\r\n                            \"operator\": \"EQ\"\r\n                        }\r\n                    ],\r\n                    \"duties\": []\r\n                }\r\n            ],\r\n            \"prohibitions\": [],\r\n            \"obligations\": [],\r\n            \"extensibleProperties\": {},\r\n            \"inheritsFrom\": null,\r\n            \"assigner\": null,\r\n            \"assignee\": null,\r\n            \"target\": \"-1736407145\",\r\n            \"@type\": {\r\n                \"@policytype\": \"set\"\r\n            }\r\n        }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{provider-data-api-url}}/policydefinitions",
+							"host": [
+								"{{provider-data-api-url}}"
+							],
+							"path": [
+								"policydefinitions"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET catalog",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-api-key",
+								"value": "password",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "{{consumer-connector-url}}/api/v1/data/catalog?providerUrl={{provider-connector-ids-url}}",
+							"host": [
+								"{{consumer-connector-url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"data",
+								"catalog"
+							],
+							"query": [
+								{
+									"key": "providerUrl",
+									"value": "{{provider-connector-ids-url}}"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}
@@ -437,12 +594,12 @@
 		},
 		{
 			"key": "asset-id",
-			"value": "148844684",
+			"value": "",
 			"type": "default"
 		},
 		{
 			"key": "contract-id",
-			"value": "DEFAULT_CONTRACT27",
+			"value": "",
 			"type": "default"
 		},
 		{


### PR DESCRIPTION
Adding this filter will intercept requests to the extension's endpoints and permit only authenticated users to access/modify internal API such as extension configuration and AAS service manipulation (e.g., adding/updating AAS shells)

Also updates corresponding documentation (changelog, README, postman-collection).