### PR TITLE
Feature: Add custom http sink to client data transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Provide digital twin (AAS) data to business partners in Data Spaces like Catena-
 
 | HTTP Method | Interface (edc:1234/api/...) ((a) = only for authenticated users) | Parameters ((r) = required) | Description |
 | :----| :----| :---- | :-------------------- |
-| POST | negotiate (a) | Query Parameter "providerUrl": URL (r), Query Parameter "assetId": String (r) | Perform an automated contract negotiation with a provider and get the data stored in the specified asset.
+| POST | negotiate (a) | Query Parameter "providerUrl": URL (r), Query Parameter "assetId": String (r), Query Parameter "dataDestinationUrl" | Perform an automated contract negotiation with a provider and get the data stored in the specified asset. Optionally, a data destination URL can be specified where the data is sent to on success.
 | GET | contractOffers (a) | Query Parameter "providerUrl": URL (r), Query Parameter "assetId": String (r) | Get all offered ContractOffers from the specified provider that contain the specified asset as data.
 | POST | negotiateContract (a) | Query Parameter "providerUrl": URL (r), request body: contractOffer (r) | Using a contractOffer and a providerUrl, negotiate a contract. Returns an agreementId on success.
-| GET | transfer (a) | Query Parameter "providerUrl": URL (r), Query Parameter "agreementId": String (r), Query Parameter "assetId": String (r) | Submits a data transfer request to the providerUrl. On success, returns the data behind the specified asset.
+| GET | transfer (a) | Query Parameter "providerUrl": URL (r), Query Parameter "agreementId": String (r), Query Parameter "assetId": String (r), Query Parameter "dataDestinationUrl" | Submits a data transfer request to the providerUrl. On success, returns the data behind the specified asset. Optionally, a data destination URL can be specified where the data is then sent to.
 | POST | contractOffers (a) | request body: List of ContractOffers (JSON) (r) | Adds the given ContractOffers to the accepted ContractOffers list: On fully automated negotiation, the provider's ContractOffer is matched against the consumer's accepted ContractOffer list. If any ContractOffer's policies fit the provider's, the negotiation continues.
 | GET | agreements (a) | Query Parameter "providerUrl": URL, Query Parameter "assetId": String | Get agreements for already negotiated contracts. These agreements are stored within the extension.
 | DELETE | agreements (a) | Query Parameter "agreementId": String (r) | Remove an agremeent of an already negotiated contract.
@@ -67,9 +67,12 @@ Provide digital twin (AAS) data to business partners in Data Spaces like Catena-
 | de.fraunhofer.iosb.ilt.faaast.service:starter | [FA³ST Service](https://github.com/FraunhoferIOSB/FAAAST-Service) to start AAS services internally.
 | io.admin-shell.aas:dataformat-json | [admin-shell-io java serializer](https://github.com/admin-shell-io/java-serializer) (de-)serialize AAS models
 | io.admin-shell.aas:model | [admin-shell-io java model](https://github.com/admin-shell-io/java-model) (de-)serialize AAS models
-| org.eclipse.edc:data-management-api | EDC asset/contract management
+| org.eclipse.edc:management-api | EDC asset/contract management
 | com.squareup.okhttp3:okhttp | Send HTTP requests to AAS services
 | jakarta.ws.rs:jakarta.ws.rs-api | provides HTTP endpoints of extension
+| org.eclipse.edc:catalog-api | Client: provider catalog access
+| org.eclipse.edc:contract-core | Client: contract agreement etc. access
+
 
 ### Configurations
 
@@ -101,6 +104,6 @@ Provide digital twin (AAS) data to business partners in Data Spaces like Catena-
 
 ## Roadmap
 Features in development:
-- Graphical interface to simplify providing and requesting AAS
+- Graphical interface to simplify providing and requesting AAS (see: https://github.com/FraunhoferIOSB/EDC-Extension-for-AAS-Dashboard)
 - Built-in client to request AAS data from other EDC (automatic contract negotiation)
 - Docker Hub container deployment

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,27 @@
 
 ## Current development version 
 
+
 **New Features**
 
 * Support of **Eclipse Dataspace Connection v0.0.1-Milestone 8**
+
+* Client Service
+    * Add custom HTTP endpoints for data transfers
+
+**Bugfixes**
+
+* Postman collection
+    * Fix some old requests
+* ContractDefinitions created by extension
+    * Validity was set to max float value, is now set to 1 year (default)
+* Dependencies
+    * Add data flow controller dependency
+
+## V1.0.0-alpha2
+This version is compatible to **Eclipse Dataspace Connection v0.0.1-Milestone 7**
+
+**New Features**
 
 * Client Service
     * Add functionality for automatically negotiating and requesting data from a provider EDC

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/client/ClientEndpoint.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/client/ClientEndpoint.java
@@ -124,7 +124,7 @@ public class ClientEndpoint {
 
         ContractOffer contractOffer;
         try {
-            contractOffer = contractOfferService.getContractForAssetId(providerUrl, assetId);
+            contractOffer = contractOfferService.getAcceptableContractForAssetId(providerUrl, assetId);
         } catch (InterruptedException negotiationException) {
             LOGGER.error(format("Getting contractOffers failed for provider %s and asset %s", providerUrl,
                     assetId), negotiationException);

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/client/contract/ContractOfferService.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/client/contract/ContractOfferService.java
@@ -143,7 +143,7 @@ public class ContractOfferService {
      * @return One contractOffer offered by the provider for the given assetId.
      * @throws InterruptedException
      */
-    public ContractOffer getContractForAssetId(URL providerUrl, String assetId)
+    public ContractOffer getAcceptableContractForAssetId(URL providerUrl, String assetId)
             throws InterruptedException {
         var contractOffers = getContractsForAssetId(providerUrl, assetId);
 

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/client/dataTransfer/TransferInitiator.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/client/dataTransfer/TransferInitiator.java
@@ -84,12 +84,7 @@ public class TransferInitiator {
      * 
      * @return A completable future whose result will be the data or an error
      *         message.
-     *
-     * @deprecated use
-     *             {@link #initiateTransferProcess(URL, String, String, HttpDataAddress)}
-     *             instead.
      */
-    @Deprecated
     public CompletableFuture<String> initiateTransferProcess(URL providerUrl, String agreementId, String assetId) {
         var apiKey = UUID.randomUUID().toString();
         dataEndpointAuthenticationRequestFilter.addTemporaryApiKey(DATA_TRANSFER_API_KEY, apiKey);
@@ -116,7 +111,6 @@ public class TransferInitiator {
      * 
      * @return A completable future whose result will be the data or an error
      *         message.
-     *
      */
     public CompletableFuture<String> initiateTransferProcess(URL providerUrl, String agreementId, String assetId,
             HttpDataAddress dataSinkAddress) {

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/client/dataTransfer/TransferInitiator.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/client/dataTransfer/TransferInitiator.java
@@ -84,7 +84,12 @@ public class TransferInitiator {
      * 
      * @return A completable future whose result will be the data or an error
      *         message.
+     *
+     * @deprecated use
+     *             {@link #initiateTransferProcess(URL, String, String, HttpDataAddress)}
+     *             instead.
      */
+    @Deprecated
     public CompletableFuture<String> initiateTransferProcess(URL providerUrl, String agreementId, String assetId) {
         var apiKey = UUID.randomUUID().toString();
         dataEndpointAuthenticationRequestFilter.addTemporaryApiKey(DATA_TRANSFER_API_KEY, apiKey);
@@ -99,6 +104,20 @@ public class TransferInitiator {
         return initiateTransferProcess(providerUrl, agreementId, assetId, dataDestination);
     }
 
+    /**
+     * Initiates the transfer process defined by the arguments. The data of the
+     * transfer will be sent to {@link ClientEndpoint#RECEIVE_DATA_PATH}.
+     * 
+     * @param providerUrl     The provider from whom the data is to be fetched.
+     * @param agreementId     Non-null ContractAgreement of the negotiation process.
+     * @param assetId         The asset to be fetched.
+     * @param dataSinkAddress HTTPDataAddress the result of the transfer should be
+     *                        sent to.
+     * 
+     * @return A completable future whose result will be the data or an error
+     *         message.
+     *
+     */
     public CompletableFuture<String> initiateTransferProcess(URL providerUrl, String agreementId, String assetId,
             HttpDataAddress dataSinkAddress) {
         // Prepare for incoming data

--- a/edc-extension4aas/src/test/java/de/fraunhofer/iosb/app/client/dataTransfer/TransferInitiatorTest.java
+++ b/edc-extension4aas/src/test/java/de/fraunhofer/iosb/app/client/dataTransfer/TransferInitiatorTest.java
@@ -16,6 +16,7 @@ import java.net.URL;
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.HttpDataAddress;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +44,15 @@ public class TransferInitiatorTest {
         when(mockStatusResult.failed()).thenReturn(false);
         transferInitiator.initiateTransferProcess(new URL("http://provider-url:1234"), "test-agreement-id",
         "test-asset");
+        verify(mockTransferProcessManager, times(1)).initiateConsumerRequest(any());
+    }
+
+    @Test
+    void testInitiateTransferProcessCustomDataAddress() throws MalformedURLException {
+        when(mockStatusResult.failed()).thenReturn(false);
+        var dataSink = HttpDataAddress.Builder.newInstance().baseUrl("http://example.com").build();
+        transferInitiator.initiateTransferProcess(new URL("http://provider-url:1234"), "test-agreement-id",
+        "test-asset", dataSink);
         verify(mockTransferProcessManager, times(1)).initiateConsumerRequest(any());
     }
 


### PR DESCRIPTION
This PR adds support of custom HTTP endpoints as data sink.

Right now, the extension keeps an endpoint open where data transfers are sent to (using temporary API keys). Users may want to have automatically fetched data from a provider EDC sent to a custom endpoint though.