### PR TITLE
Fix: client not reading config

### DIFF
--- a/client/src/main/java/de/fraunhofer/iosb/client/ClientExtension.java
+++ b/client/src/main/java/de/fraunhofer/iosb/client/ClientExtension.java
@@ -53,7 +53,7 @@ public class ClientExtension implements ServiceExtension {
         @Override
         public void initialize(ServiceExtensionContext context) {
                 var monitor = context.getMonitor();
-                var config = context.getConfig();
+                var config = context.getConfig("edc.client");
 
                 var policyController = new PolicyController(monitor, catalogService, transformer, config);
 

--- a/client/src/main/java/de/fraunhofer/iosb/client/dataTransfer/DataTransferController.java
+++ b/client/src/main/java/de/fraunhofer/iosb/client/dataTransfer/DataTransferController.java
@@ -122,7 +122,7 @@ public class DataTransferController {
             return data;
         } catch (TimeoutException transferTimeoutExceededException) {
             dataTransferObservable.unregister(agreementId);
-            throw new EdcException(format("Waiting for an transfer failed for agreementId: %s", agreementId),
+            throw new EdcException(format("Waiting for a transfer failed for agreementId: %s", agreementId),
                     transferTimeoutExceededException);
         }
     }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     implementation("$group:data-plane-client:$edcVersion")
     implementation("$group:data-plane-selector-client:$edcVersion")
     implementation("$group:data-plane-selector-core:$edcVersion")
-    implementation("$group:data-plane-selector-api:$edcVersion")
     implementation("$group:transfer-data-plane:$edcVersion")
 
 }


### PR DESCRIPTION
The client extension was not propagating the correct configuration to its components. As a result, the client configuration could not be read by the components

Fixed by getting a relative configuration instead of the whole EDC config