### PR TITLE
Fix: Service.with() method

### DIFF
--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/AasExtension.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/AasExtension.java
@@ -167,11 +167,11 @@ public class AasExtension implements ServiceExtension {
         registerAasServicesByConfig(serviceRepository);
     }
 
-    private void registerAasServicesByConfig(ServiceRepository selfDescriptionRepository) {
+    private void registerAasServicesByConfig(ServiceRepository serviceRepository) {
         var configInstance = Configuration.getInstance();
 
         if (Objects.nonNull(configInstance.getRemoteAasLocation())) {
-            selfDescriptionRepository.create(new Service(configInstance.getRemoteAasLocation()));
+            serviceRepository.create(new Service(configInstance.getRemoteAasLocation()));
         }
 
         if (Objects.isNull(configInstance.getLocalAasModelPath())) {
@@ -196,7 +196,7 @@ public class AasExtension implements ServiceExtension {
             return;
         }
 
-        selfDescriptionRepository.create(new Service(serviceUrl));
+        serviceRepository.create(new Service(serviceUrl));
     }
 
     @Override

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/model/aas/service/Service.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/model/aas/service/Service.java
@@ -21,9 +21,9 @@ import de.fraunhofer.iosb.model.aas.net.AasAccessUrl;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nullable;
 import java.net.MalformedURLException;
 import java.net.URL;
-import javax.annotation.Nullable;
 
 /**
  * An AAS service representation as seen in <a href="https://github.com/FraunhoferIOSB/FAAAST-Service">FA³ST Service</a>
@@ -66,15 +66,25 @@ public final class Service extends AasProvider {
         super(provider);
     }
 
-    public @NotNull Service with(Asset environment) {
+    private Service(AasProvider provider, @Nullable Asset environment) {
+        super(provider);
         this.environment = environment;
-        return this;
+    }
+
+    /**
+     * Return the current Service with the given environment.
+     * This creates a new object reference.
+     *
+     * @param environment The environment
+     * @return A new object containing this service's metadata and the environment.
+     */
+    public @NotNull Service with(Asset environment) {
+        return new Service(this, environment);
     }
 
     public Asset environment() {
         return environment;
     }
-
 
     public URL getShellsUrl() throws MalformedURLException {
         return new URL(getAccessUrl(), SHELLS_PATH);

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/model/aas/service/ServiceRepositoryUpdater.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/model/aas/service/ServiceRepositoryUpdater.java
@@ -25,10 +25,10 @@ import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
  */
 public class ServiceRepositoryUpdater extends PipelineStep<Service, Pair<Asset, Asset>> {
 
-    private final ServiceRepository selfDescriptionRepository;
+    private final ServiceRepository services;
 
-    public ServiceRepositoryUpdater(ServiceRepository selfDescriptionRepository) {
-        this.selfDescriptionRepository = selfDescriptionRepository;
+    public ServiceRepositoryUpdater(ServiceRepository serviceRepository) {
+        this.services = serviceRepository;
     }
 
     /**
@@ -41,8 +41,13 @@ public class ServiceRepositoryUpdater extends PipelineStep<Service, Pair<Asset, 
      */
     @Override
     public PipelineResult<Pair<Asset, Asset>> apply(Service service) {
-        var old = selfDescriptionRepository.getEnvironment(service.getAccessUrl());
-        selfDescriptionRepository.update(service);
+        var old = services.getEnvironment(service.getAccessUrl());
+
+        if (old != null) {
+            // Create deep copy of old asset
+            old = old.toBuilder().build();
+        }
+        services.update(service);
 
         return PipelineResult.success(new Pair<>(old, service.environment()));
     }

--- a/edc-extension4aas/src/test/java/de/fraunhofer/iosb/app/model/aas/service/ServiceTest.java
+++ b/edc-extension4aas/src/test/java/de/fraunhofer/iosb/app/model/aas/service/ServiceTest.java
@@ -1,0 +1,27 @@
+package de.fraunhofer.iosb.app.model.aas.service;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class ServiceTest {
+
+    @Test
+    void testWithReturnsDifferentObjectReference() throws MalformedURLException {
+        Service myService = new Service(new URL("http://aas-access-url"));
+
+        var environment = Asset.Builder.newInstance().build();
+        Service withedService = myService.with(environment);
+
+        // Compares reference
+        assertNotSame(myService, withedService);
+        // The "old" service should also not copy the new one's environment
+        assertNotEquals(environment, myService.environment());
+    }
+
+}


### PR DESCRIPTION
Right now there is a bug which results in the assetIndex / contractStore not being populated by the AAS elements.

This is due to the "Service.with(Environment)" method which returns a reference to itself instead of creating a new object with its metadata and the given environment as a field.