### PR TITLE
Unify jersey version

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -8,6 +8,7 @@ val edcVersion: String by project
 val rsApi: String by project
 val mockitoVersion: String by project
 val mockserverVersion: String by project
+val jerseyVersion: String by project
 
 java {
     toolchain {
@@ -30,9 +31,9 @@ dependencies {
     implementation("$group:management-api:$edcVersion") // EDC WebService for registering endpoints
 
     testImplementation("$group:junit:$edcVersion")
-    testImplementation("org.glassfish.jersey.core:jersey-common:3.1.9")
-    testImplementation("org.mockito:mockito-core:${mockitoVersion}")
-    testImplementation("org.mock-server:mockserver-junit-jupiter:${mockserverVersion}")
+    testImplementation("org.glassfish.jersey.core:jersey-common:$jerseyVersion")
+    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation("org.mock-server:mockserver-junit-jupiter:$mockserverVersion")
 }
 
 repositories {

--- a/edc-extension4aas/build.gradle.kts
+++ b/edc-extension4aas/build.gradle.kts
@@ -9,6 +9,7 @@ val edcVersion: String by project
 val rsApi: String by project
 val mockitoVersion: String by project
 val mockserverVersion: String by project
+val jerseyVersion: String by project
 
 java {
     toolchain {
@@ -25,7 +26,7 @@ dependencies {
     implementation("$group:management-api:$edcVersion")
 
     testImplementation("$group:junit:$edcVersion")
-    testImplementation("org.glassfish.jersey.core:jersey-common:3.1.8")
+    testImplementation("org.glassfish.jersey.core:jersey-common:$jerseyVersion")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation("org.mock-server:mockserver-junit-jupiter:${mockserverVersion}")
     testImplementation("org.mock-server:mockserver-netty:${mockserverVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ aas4jVersion=1.0.2
 mockitoVersion=5.2.0
 jupiterVersion=5.10.2
 mockserverVersion=5.15.0
+jerseyVersion=3.1.9

--- a/public-api-management/build.gradle.kts
+++ b/public-api-management/build.gradle.kts
@@ -8,6 +8,7 @@ val edcVersion: String by project
 val rsApi: String by project
 val mockitoVersion: String by project
 val mockserverVersion: String by project
+val jerseyVersion: String by project
 
 java {
     toolchain {
@@ -20,7 +21,7 @@ dependencies {
     implementation("$group:auth-spi:$edcVersion")
 
     testImplementation("$group:junit:$edcVersion")
-    testImplementation("org.glassfish.jersey.core:jersey-common:3.1.8")
+    testImplementation("org.glassfish.jersey.core:jersey-common:$jerseyVersion")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation("org.mock-server:mockserver-junit-jupiter:${mockserverVersion}")
 }


### PR DESCRIPTION
So that dependabot only creates one pr for a version update