### PR TITLE
Fix/non-local transfer terminated error

### DIFF
--- a/client/src/main/java/de/fraunhofer/iosb/client/datatransfer/DataTransferEndpoint.java
+++ b/client/src/main/java/de/fraunhofer/iosb/client/datatransfer/DataTransferEndpoint.java
@@ -61,7 +61,7 @@ public class DataTransferEndpoint {
     @POST
     @Path("receiveData/{agreement}")
     public Response receiveData(@PathParam("agreement") String agreementId, String requestBody) {
-        monitor.info(format("[Client] Receiving data for agreement %s...", agreementId));
+        monitor.info(format("Receiving data for agreement %s...", agreementId));
         Objects.requireNonNull(agreementId);
         Objects.requireNonNull(requestBody);
         observable.update(agreementId, requestBody);

--- a/client/src/main/java/de/fraunhofer/iosb/client/datatransfer/DataTransferObservable.java
+++ b/client/src/main/java/de/fraunhofer/iosb/client/datatransfer/DataTransferObservable.java
@@ -81,10 +81,13 @@ class DataTransferObservable implements TransferProcessListener {
 
     @Override
     public void terminated(TransferProcess transferProcess) {
-        observers.get(transferProcess.getContractId())
-                .completeExceptionally(
-                        new EdcException("Transfer process terminated. Reason: %s"
-                                .formatted(transferProcess.getErrorDetail())));
+        var errorMessage = "Transfer process terminated. Reason: %s".formatted(transferProcess.getErrorDetail());
+        var observer = observers.get(transferProcess.getContractId());
+        if (observer != null) {
+            observer.completeExceptionally(new EdcException(errorMessage));
+        } else {
+            monitor.severe(errorMessage);
+        }
     }
 
 }

--- a/client/src/main/java/de/fraunhofer/iosb/client/datatransfer/DataTransferObservable.java
+++ b/client/src/main/java/de/fraunhofer/iosb/client/datatransfer/DataTransferObservable.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -30,11 +31,11 @@ import static java.lang.String.format;
  * Gets notified about incoming data by a provider connector.
  * Also notified by the transfer process observable regarding termination of transfer processes
  */
-class DataTransferObservable implements TransferProcessListener {
+class DataTransferObservable<T> implements TransferProcessListener {
 
     private final Monitor monitor;
 
-    private final Map<String, CompletableFuture<String>> observers;
+    private final Map<String, CompletableFuture<T>> observers;
 
     DataTransferObservable(Monitor monitor) {
         this.monitor = monitor;
@@ -45,9 +46,9 @@ class DataTransferObservable implements TransferProcessListener {
      * Register a future that should complete if a data transfer is finished.
      *
      * @param agreementId The agreement ID this future is dependent on.
-     * @return Object containing data in case of transfer.
+     * @return Future containing data in case of transfer.
      */
-    CompletableFuture<String> register(String agreementId) {
+    CompletableFuture<T> register(String agreementId) {
         observers.put(agreementId, new CompletableFuture<>());
         return observers.get(agreementId);
     }
@@ -68,7 +69,7 @@ class DataTransferObservable implements TransferProcessListener {
      * @param agreementId The agreementId coming with a provider's data transfer
      * @param data        Any data by a provider connector
      */
-    void update(String agreementId, String data) {
+    void update(String agreementId, T data) {
         if (!observers.containsKey(agreementId)) {
             monitor.warning(format(
                     "A POST request to the client's data transfer endpoint with an unknown agreementID was caught. " +
@@ -82,12 +83,8 @@ class DataTransferObservable implements TransferProcessListener {
     @Override
     public void terminated(TransferProcess transferProcess) {
         var errorMessage = "Transfer process terminated. Reason: %s".formatted(transferProcess.getErrorDetail());
-        var observer = observers.get(transferProcess.getContractId());
-        if (observer != null) {
-            observer.completeExceptionally(new EdcException(errorMessage));
-        } else {
-            monitor.severe(errorMessage);
-        }
+        Optional.ofNullable(observers.get(transferProcess.getContractId()))
+                .ifPresentOrElse(observer -> observer.completeExceptionally(new EdcException(errorMessage)),
+                        () -> monitor.severe(errorMessage));
     }
-
 }

--- a/client/src/test/java/de/fraunhofer/iosb/client/datatransfer/DataTransferObservableTest.java
+++ b/client/src/test/java/de/fraunhofer/iosb/client/datatransfer/DataTransferObservableTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.client.datatransfer;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DataTransferObservableTest {
+
+    private final Monitor mockMonitor = mock(Monitor.class);
+    private DataTransferObservable<String> testSubject;
+
+    @BeforeEach
+    void setUp() {
+        testSubject = createTestInstance();
+    }
+
+    @Test
+    void test_register_normalBehavior() {
+        // Verify non-exceptional behavior
+        var agreementId = UUID.randomUUID().toString();
+
+        CompletableFuture<String> future = testSubject.register(agreementId);
+
+        // Check that future is not complete by accident
+        assertEquals("absent", future.getNow("absent"));
+    }
+
+    @Test
+    void test_register_unregister() {
+        // Verify non-exceptional behavior
+        var agreementId = UUID.randomUUID().toString();
+
+        testSubject.register(agreementId);
+        testSubject.unregister(agreementId);
+    }
+
+    @Test
+    void test_unregister_nonexistentObserver() {
+        // Verify non-exceptional behavior
+        testSubject.unregister(UUID.randomUUID().toString());
+    }
+
+    @Test
+    void test_update_normalBehavior() throws ExecutionException, InterruptedException {
+        var agreementId = UUID.randomUUID().toString();
+        var data = "test data\r\nhello world";
+        var observer = testSubject.register(agreementId);
+        testSubject.update(agreementId, data);
+
+        assertEquals(data, observer.get());
+    }
+
+    @Test
+    void test_update_nullData() throws ExecutionException, InterruptedException {
+        var agreementId = UUID.randomUUID().toString();
+        var observer = testSubject.register(agreementId);
+        testSubject.update(agreementId, null);
+
+        assertNull(observer.get());
+    }
+
+    @Test
+    void test_terminated_nonexistentObserver() {
+        var mockTransferProcess = mock(TransferProcess.class);
+        when(mockTransferProcess.getErrorDetail()).thenReturn("Test error detail");
+        when(mockTransferProcess.getContractId()).thenReturn("test-contract-id");
+
+        testSubject.terminated(mockTransferProcess);
+
+        verify(mockMonitor).severe(argThat((String message) -> message.contains("Test error detail")));
+    }
+
+    private DataTransferObservable<String> createTestInstance() {
+        return new DataTransferObservable<>(mockMonitor);
+    }
+
+}


### PR DESCRIPTION
An NPE occurs when a remote data transfer destination is used (i.e. a DataAddress is given with the dataTransfer request) and the transfer process is terminated. The extension would look for the future waiting for the data but since the destination is remote no such future exists.