### PR TITLE
Fix: Don't throw error if not accepting self-signed

### DIFF
--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/AasExtension.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/AasExtension.java
@@ -191,8 +191,8 @@ public class AasExtension implements ServiceExtension {
                     configInstance.getLocalAasServicePort(),
                     aasConfigPath);
         } catch (Exception startAssetAdministrationShellException) {
-            monitor.severe("Could not start AAS service provided by configuration",
-                    startAssetAdministrationShellException);
+            monitor.severe("Could not start / register AAS service provided by configuration.\nReason: %s"
+                    .formatted(startAssetAdministrationShellException.getMessage()));
             return;
         }
 


### PR DESCRIPTION
This occurs when service with trusted or unencrypted connection is registered