### PR TITLE
Fix unencrypted and trusted services failing registration

### DIFF
--- a/data-plane-aas/src/main/java/de/fraunhofer/iosb/aas/AasDataProcessorFactory.java
+++ b/data-plane-aas/src/main/java/de/fraunhofer/iosb/aas/AasDataProcessorFactory.java
@@ -88,7 +88,7 @@ public abstract class AasDataProcessorFactory {
     protected abstract Result<Certificate[]> getCertificates(URL url);
 
     protected Result<@Nullable Certificate[]> retrieveCertificates(URL aasUrl) {
-        if (isTrusted(aasUrl)) {
+        if (isTrusted(aasUrl) || "http".equalsIgnoreCase(aasUrl.getProtocol())) {
             return Result.success(null);
         }
 

--- a/data-plane-aas/src/main/java/de/fraunhofer/iosb/aas/impl/RegisteredAasDataProcessorFactory.java
+++ b/data-plane-aas/src/main/java/de/fraunhofer/iosb/aas/impl/RegisteredAasDataProcessorFactory.java
@@ -29,6 +29,8 @@ import java.net.URL;
 import java.security.cert.Certificate;
 import java.util.Set;
 
+import static de.fraunhofer.iosb.ssl.impl.DefaultSelfSignedCertificateRetriever.isTrusted;
+
 public class RegisteredAasDataProcessorFactory extends AasDataProcessorFactory {
 
     private final Set<AasAccessUrl> registeredAasServices;
@@ -43,6 +45,10 @@ public class RegisteredAasDataProcessorFactory extends AasDataProcessorFactory {
 
     @Override
     protected Result<@Nullable Certificate[]> getCertificates(URL url) {
+        if (isTrusted(url) || "http".equalsIgnoreCase(url.getProtocol())) {
+            return Result.success(null);
+        }
+
         if (registeredAasServices == null || !registeredAasServices.contains(new AasAccessUrl(url))) {
             return Result.failure("AAS service is not registered and allowing all self-signed certificates is " +
                     "disabled");


### PR DESCRIPTION
unencrypted = non-ssl encrypted services (http)
trusted = a trusted certificate is used by the service