### PR TITLE
Feat: synchronize pipeline calls

### DIFF
--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/aas/agent/AasAgent.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/aas/agent/AasAgent.java
@@ -61,6 +61,7 @@ public abstract class AasAgent<T extends AasProvider, U> extends PipelineStep<T,
         var responseResult = executeRequest(processor, dataAddress);
 
         if (responseResult.failed()) {
+            responseResult.getContent().close();
             return Result.failure("Reading %s from %s failed: %s"
                     .formatted(clazz.getName(), path, responseResult.getFailureDetail()));
         }
@@ -76,8 +77,8 @@ public abstract class AasAgent<T extends AasProvider, U> extends PipelineStep<T,
     }
 
     private Result<Response> executeRequest(AasDataProcessor processor, AasDataAddress dataAddress) {
-        try {
-            return Result.success(processor.send(dataAddress));
+        try(var response = processor.send(dataAddress)) {
+            return Result.success(response);
         } catch (IOException httpIOException) {
             return Result.failure(List.of(httpIOException.getClass().getSimpleName(), httpIOException.getMessage()));
         }

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/util/VariableRateScheduler.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/util/VariableRateScheduler.java
@@ -54,7 +54,7 @@ public class VariableRateScheduler extends ScheduledThreadPoolExecutor implement
     public void scheduleAtVariableRate(Supplier<Integer> rateSupplier) {
         schedule(() -> {
             try {
-                runnable.run();
+                runRunnable();
             } catch (Exception e) {
                 monitor.severe("VariableRateScheduler stopped execution.", e);
                 throw new EdcException(e);
@@ -63,13 +63,17 @@ public class VariableRateScheduler extends ScheduledThreadPoolExecutor implement
         }, (long) rateSupplier.get(), TimeUnit.SECONDS);
     }
 
-    @Override
-    public void created(Registry registry) {
+    private synchronized void runRunnable() {
         runnable.run();
     }
 
     @Override
+    public void created(Registry registry) {
+        runRunnable();
+    }
+
+    @Override
     public void created(Service service) {
-        runnable.run();
+        runRunnable();
     }
 }


### PR DESCRIPTION
When service/registry pipeline was running and a new service/registry was added, the pipeline would run simultaneously, leaving the extension in an undefined state

Now, calls to a pipeline are synchronized