### PR TITLE
feat: optional aas data plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ In this section, dependencies from EDC and third-party are listed. (Dependencies
 | localAASServicePort         | Open network port | Port to locally created AAS service. Required, if localAASModelPath is defined and localAASServiceConfigPath is not defined.                                                     |
 | onlySubmodels               | boolean           | (Provider) Only register submodels of AAS services. Default: True                                                                                                                |
 | remoteAasLocation           | URL               | Register a URL of an AAS service (such as FA³ST) that is already running and is conformant with official AAS API specification                                                   |
+| useAasDataPlane             | boolean           | Whether to use AAS data plane or HTTP DataPlane to register AAS elements. (Default: False)                                                                                       |
 | syncPeriod                  | number in seconds | Time period in which AAS services should be polled for structural changes (added/deleted elements etc.). Default: 50 (seconds).                                                  |
 
 </details>
@@ -170,7 +171,7 @@ In this section, dependencies from EDC and third-party are listed. (Dependencies
 
 | Key (edc.client.)             | Value Type              | Description                                                                                                                                                                   |
 |:------------------------------|:------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| acceptAllProviderOffers       | <u>True</u>/False       | Accept any contractOffer offered by all provider connectors on automated contract negotiation (e.g., trusted provider)                                                        |
+| acceptAllProviderOffers       | boolean                 | Accept any contractOffer offered by all provider connectors on automated contract negotiation (e.g., trusted provider)                                                        |
 | acceptedPolicyDefinitionsPath | path                    | Path pointing to a JSON-file containing acceptable PolicyDefinitions for automated contract negotiation in a list (only policies must match in a provider's PolicyDefinition) |
 | waitForAgreementTimeout       | whole number in seconds | How long should the extension wait for an agreement when automatically negotiating a contract? Default value is 20(s).                                                        |
 | waitForCatalogTimeout         | whole number in seconds | How long should the extension wait for a catalog? Default value is 20(s).                                                                                                     |

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,12 @@ Compatibility: **Eclipse Dataspace Connector v0.13.0**
 
 **New Features**
 
+* AAS DataPlane is now optional
+    * Configuration variable `edc.aas.useAasDataPlane`, default value `False`
+    * Use cases:
+        * Better integration into existing EDC deployments
+        * Use existing Http DataPlane
+        * If there is no need for proxy functionality like ProxyMethod or ProxyBody to trigger AAS operations
 * AAS registries (spec, example) can now be registered at the extension.
     * Add a FA³ST Registry / AAS registry by URL
     * The extension reads the shell-/submodel-descriptors and registers assets for their endpoints

--- a/edc-extension4aas/build.gradle.kts
+++ b/edc-extension4aas/build.gradle.kts
@@ -22,7 +22,8 @@ dependencies {
     implementation(project(":aas-lib"))
 
     implementation("de.fraunhofer.iosb.ilt.faaast.service:starter:$faaastVersion")
-    implementation("${group}:http-lib:$edcVersion")
+    implementation("${group}:http-lib:${edcVersion}")
+    implementation("${group}:data-plane-http-spi:${edcVersion}") // HTTPDataAddress
     implementation("$group:asset-api:$edcVersion")
 
     testImplementation("$group:junit:$edcVersion")

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/aas/EnvironmentToAssetMapper.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/aas/EnvironmentToAssetMapper.java
@@ -17,8 +17,9 @@ package de.fraunhofer.iosb.app.aas;
 
 import de.fraunhofer.iosb.aas.lib.model.AasProvider;
 import de.fraunhofer.iosb.aas.lib.model.impl.Service;
+import de.fraunhofer.iosb.app.aas.mapper.AssetAdministrationShellMapper;
 import de.fraunhofer.iosb.app.aas.mapper.ConceptDescriptionMapper;
-import de.fraunhofer.iosb.app.aas.mapper.ShellToAssetMapper;
+import de.fraunhofer.iosb.app.aas.mapper.Mapper;
 import de.fraunhofer.iosb.app.aas.mapper.SubmodelMapper;
 import de.fraunhofer.iosb.app.pipeline.PipelineFailure;
 import de.fraunhofer.iosb.app.pipeline.PipelineResult;
@@ -53,9 +54,9 @@ public class EnvironmentToAssetMapper extends PipelineStep<Map<Service, Environm
     private static final String SUBMODELS = "submodels";
 
     private final Supplier<Boolean> onlySubmodelsDecision;
-    private final ShellToAssetMapper shellMapper = new ShellToAssetMapper();
-    private final SubmodelMapper submodelMapper;
-    private final ConceptDescriptionMapper conceptDescriptionMapper = new ConceptDescriptionMapper();
+    private final Mapper<AssetAdministrationShell> shellMapper = new AssetAdministrationShellMapper();
+    private final Mapper<Submodel> submodelMapper;
+    private final Mapper<ConceptDescription> conceptDescriptionMapper = new ConceptDescriptionMapper();
 
 
     public EnvironmentToAssetMapper(Supplier<Boolean> onlySubmodelsDecision) {

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/aas/mapper/AssetAdministrationShellMapper.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/aas/mapper/AssetAdministrationShellMapper.java
@@ -20,7 +20,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 
-public class ShellToAssetMapper extends ElementMapper implements Mapper<AssetAdministrationShell> {
+public class AssetAdministrationShellMapper extends ElementMapper implements Mapper<AssetAdministrationShell> {
 
     public Asset map(AssetAdministrationShell shell, AasProvider provider) {
         var dataAddress = createDataAddress(provider, createReference(KeyTypes.ASSET_ADMINISTRATION_SHELL,

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/aas/mapper/SubmodelMapper.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/aas/mapper/SubmodelMapper.java
@@ -33,7 +33,6 @@ public class SubmodelMapper extends ElementMapper implements Mapper<Submodel> {
     private final Supplier<Boolean> onlySubmodelsDecision;
 
     public SubmodelMapper(Supplier<Boolean> onlySubmodelsDecision) {
-        super();
         this.onlySubmodelsDecision = onlySubmodelsDecision;
     }
 

--- a/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/model/configuration/Configuration.java
+++ b/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/model/configuration/Configuration.java
@@ -57,6 +57,9 @@ public class Configuration {
     @JsonProperty(SETTINGS_PREFIX + "defaultContractPolicyPath")
     private String defaultContractPolicyPath;
 
+    @JsonProperty(SETTINGS_PREFIX + "useAasDataPlane")
+    private boolean useAasDataPlane;
+
 
     public static synchronized Configuration getInstance() {
         if (instance == null) {
@@ -104,4 +107,9 @@ public class Configuration {
     public boolean isAllowSelfSignedCertificates() {
         return allowSelfSignedCertificates;
     }
+
+    public boolean isUseAasDataPlane() {
+        return useAasDataPlane;
+    }
+
 }


### PR DESCRIPTION
Makes AAS DataPlane optional (opt-in)
- Configuration variable `edc.aas.useAasDataPlane`, default value `False`
- Use cases:
    - Better integration into existing EDC deployments
    - Use existing Http DataPlane
    - If there is no need for proxy functionality like ProxyMethod or ProxyBody to trigger AAS operations


Alternative to configuration would have been checking if AAS/HTTP data plane is available, but data planes can (dis)appear at any time. Deliberately configuring the extension to work with AAS data plane enables deployer to decide which data plane to use