### PR TITLE
Fix: Update config, docker extension version

### DIFF
--- a/example/configurations/docker-consumer.properties
+++ b/example/configurations/docker-consumer.properties
@@ -14,7 +14,7 @@ web.http.management.path=/management
 web.http.protocol.port=9292
 web.http.protocol.path=/dsp
 edc.dsp.callback.address=http://consumer:9292/dsp
-edc.api.auth.key=password
+web.http.management.auth.key=password
 # GUI configuration (enable DataDashboard to communicate with EDC)
 edc.web.rest.cors.enabled=true
 edc.web.rest.cors.origins=*

--- a/example/configurations/docker-provider.properties
+++ b/example/configurations/docker-provider.properties
@@ -8,6 +8,7 @@ edc.aas.localAASServicePort=8080
 # edc.aas.remoteAasLocation = http://example.com/aas
 # Period of synchronizing the EDC assetStore with the connected AAS services (in seconds)
 edc.aas.syncPeriod=100
+edc.aas.useAasDataPlane=True
 edc.aas.allowSelfSignedCertificates=True
 edc.dataplane.aas.acceptForeignSelfSignedCertificates=False
 edc.dataplane.aas.acceptOwnSelfSignedCertificates=True
@@ -37,7 +38,7 @@ edc.transfer.functions.enabled.protocols=http
 # Connector hostname, which e.g. is used in referer urls
 edc.hostname=provider
 # Auth key for using internal EDC api (header key: x-api-key)
-edc.api.auth.key=password
+web.http.management.auth.key=password
 # GUI configuration (enable DataDashboard to communicate with EDC)
 edc.web.rest.cors.enabled=true
 edc.web.rest.cors.origins=*

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.9"
-
 services:
   provider:
-    image: fraunhoferiosb/edc-extension4aas:2.2.1
+    image: fraunhoferiosb/edc-extension4aas:latest
     ports:
       - "8181:8181"
       - "8281:8281"


### PR DESCRIPTION
Currently, the docker example with the dockerhub images uses an old version for the provider extension as well as some old configuration values.

Also, since using AAS data plane is optional but needed in order to use AAS services with self-signed certificates, explicitly enable AAS data plane for provider