### PR TITLE
feat: update edc version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Current development version
 
-Compatibility: **Eclipse Dataspace Connector v0.13.0**
+Compatibility: **Eclipse Dataspace Connector v0.13.0, v0.13.2**
 
 **New Features**
 
@@ -32,6 +32,8 @@ Compatibility: **Eclipse Dataspace Connector v0.13.0**
 
 * NPE on transfer terminated signal when transferring data to the extension
 * Null-checks in various files
+* Set docker-compose extension versions to "latest"
+* 
 
 **Miscellaneous**
 
@@ -51,8 +53,8 @@ Compatibility: **Eclipse Dataspace Connector v0.13.0**
       described above.
     * This makes the extension not rely on custom data classes which can be invalidated through an update of AAS or EDC
     * It also makes (de)serialization of AAS environments easier
-* Updated FA³ST to version v1.1.0
-* Updated EDC to version v0.10.0
+* Updated FA³ST to version v1.2.0
+* Updated EDC to version v0.13.2
 * Removed custom dependency injection because of transitive dependency issue from FA³ST service
     * This was in `example/build.gradle.kts`
 * Added tests

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 javaVersion=17
 group=org.eclipse.edc
-edcVersion=0.13.0
+edcVersion=0.13.2
 faaastVersion=1.2.0
 aas4jVersion=1.0.4
 mockitoVersion=5.18.0


### PR DESCRIPTION
The extension is compatible with EDC v0.13.0 and v0.13.2 - v0.13.1 does not seem to have release artifacts (cf. https://repo.maven.apache.org/maven2/org/eclipse/edc/connector-core/)