### PR TITLE
fix: loading of access/usage policy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 
 ### Bugfixes
 
+* Fixed loading/deserializing default access / contract policies
+* Fixed build goal by including duplicate files
+
 ### Miscellaneous
 
 ## V2.3.0

--- a/extensions/common/aas-lib/src/main/java/de/fraunhofer/iosb/aas/lib/model/PolicyBinding.java
+++ b/extensions/common/aas-lib/src/main/java/de/fraunhofer/iosb/aas/lib/model/PolicyBinding.java
@@ -25,7 +25,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_POLICY_DEFINITION_ID;
+import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_ACCESS_POLICY_DEFINITION_ID;
+import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_USAGE_POLICY_DEFINITION_ID;
 
 
 /**
@@ -45,8 +46,8 @@ public record PolicyBinding(Reference referredElement, @JsonAlias("accessPolicyI
     public static PolicyBinding ofDefaults(Reference reference) {
         return new Builder()
                 .withReferredElement(ReferenceHelper.asString(reference))
-                .withAccessPolicyDefinitionId(DEFAULT_POLICY_DEFINITION_ID)
-                .withContractPolicyDefinitionId(DEFAULT_POLICY_DEFINITION_ID)
+                .withAccessPolicyDefinitionId(DEFAULT_ACCESS_POLICY_DEFINITION_ID)
+                .withContractPolicyDefinitionId(DEFAULT_USAGE_POLICY_DEFINITION_ID)
                 .build();
     }
 

--- a/extensions/common/constants/src/main/java/de/fraunhofer/iosb/constants/AasConstants.java
+++ b/extensions/common/constants/src/main/java/de/fraunhofer/iosb/constants/AasConstants.java
@@ -16,6 +16,7 @@
 package de.fraunhofer.iosb.constants;
 
 import java.util.Set;
+import java.util.UUID;
 
 
 public interface AasConstants {
@@ -25,7 +26,8 @@ public interface AasConstants {
 
     String EDC_SETTINGS_PREFIX = "edc.aas";
 
-    String DEFAULT_POLICY_DEFINITION_ID = "allow_all";
+    String DEFAULT_ACCESS_POLICY_DEFINITION_ID = UUID.randomUUID().toString();
+    String DEFAULT_USAGE_POLICY_DEFINITION_ID = UUID.randomUUID().toString();
 
     /**
      * The fields in this set are added as additional metadata in the catalog and self-description, unless configured

--- a/extensions/control-plane/codec/src/main/java/de/fraunhofer/iosb/codec/Codec.java
+++ b/extensions/control-plane/codec/src/main/java/de/fraunhofer/iosb/codec/Codec.java
@@ -66,7 +66,7 @@ public class Codec {
     }
 
 
-    public <T extends Entity> Result<T> deserialize(String entityJson, Class<T> type) {
+    public <T> Result<T> deserialize(String entityJson, Class<T> type) {
         var assetJsonObject = Json.createReader(new StringReader(entityJson)).readObject();
 
         var expandedResult = jsonLd.expand(assetJsonObject);

--- a/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/AasExtension.java
+++ b/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/AasExtension.java
@@ -29,6 +29,7 @@ import de.fraunhofer.iosb.app.handler.edc.EdcStoreHandler;
 import de.fraunhofer.iosb.app.model.configuration.Configuration;
 import de.fraunhofer.iosb.app.stores.repository.AasServerStore;
 import de.fraunhofer.iosb.client.exception.UnauthorizedException;
+import de.fraunhofer.iosb.codec.Codec;
 import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
 import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
@@ -43,7 +44,6 @@ import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.Hostname;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.WebService;
 
 import java.net.ConnectException;
@@ -67,14 +67,14 @@ public class AasExtension implements ServiceExtension {
 
     public static final String NAME = "EDC4AAS Extension";
 
-    @Inject
-    private TypeTransformerRegistry typeTransformerRegistry;
     @Inject // Register public endpoints
     private PublicApiManagementService publicApiManagementService;
     @Inject
     private AssetIndex assetIndex;
     @Inject
     private ContractDefinitionStore contractDefinitionStore;
+    @Inject
+    private Codec codec;
     @Inject
     private Hostname hostname;
     @Inject(required = false)
@@ -129,7 +129,7 @@ public class AasExtension implements ServiceExtension {
     @Override
     public void start() {
         try {
-            PolicyHelper.registerDefaultPolicies(typeTransformerRegistry, monitor, policyDefinitionStore, participantId.get());
+            PolicyHelper.registerDefaultPolicies(codec, monitor, policyDefinitionStore, participantId.get());
             bootstrapRepositories();
         }
         catch (UnauthorizedException e) {

--- a/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/edc/policy/PolicyHelper.java
+++ b/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/edc/policy/PolicyHelper.java
@@ -15,9 +15,8 @@
  */
 package de.fraunhofer.iosb.app.edc.policy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iosb.app.model.configuration.Configuration;
-import jakarta.json.JsonObject;
+import de.fraunhofer.iosb.codec.Codec;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Action;
@@ -26,12 +25,13 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.StoreResult;
-import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_POLICY_DEFINITION_ID;
+import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_ACCESS_POLICY_DEFINITION_ID;
+import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_USAGE_POLICY_DEFINITION_ID;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_USE_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
 
@@ -44,37 +44,50 @@ public abstract class PolicyHelper {
     /**
      * Register default access and contract policies either by configuration variables or using internal (minimal) policies.
      *
-     * @param typeTransformerRegistry Deserialize policy
+     * @param codec Deserialize policy
      * @param monitor monitor to log messages.
      * @param policyDefinitionStore Store implementation to register policies.
      * @param participantId Used for the default policies.
      */
-    public static void registerDefaultPolicies(TypeTransformerRegistry typeTransformerRegistry, Monitor monitor, PolicyDefinitionStore policyDefinitionStore,
+    public static void registerDefaultPolicies(Codec codec, Monitor monitor, PolicyDefinitionStore policyDefinitionStore,
                                                String participantId) {
         Configuration configuration = Configuration.getInstance();
 
-        Policy defaultPolicy = getPolicy(typeTransformerRegistry, monitor, participantId, configuration.getDefaultAccessPolicyPath());
+        Policy defaultAccessPolicy = getPolicy(codec, monitor, participantId, configuration.getDefaultAccessPolicyPath());
+        Policy defaultUsagePolicy = getPolicy(codec, monitor, participantId, configuration.getDefaultContractPolicyPath());
 
-        var defaultPolicyDefinition = PolicyDefinition.Builder.newInstance()
-                .id(DEFAULT_POLICY_DEFINITION_ID)
-                .policy(defaultPolicy)
+        var defaultAccessPolicyDefinition = PolicyDefinition.Builder.newInstance()
+                .id(DEFAULT_ACCESS_POLICY_DEFINITION_ID)
+                .policy(defaultAccessPolicy)
                 .participantContextId(participantId)
                 .build();
 
-        StoreResult<PolicyDefinition> storeResult = policyDefinitionStore.create(defaultPolicyDefinition);
+        StoreResult<PolicyDefinition> accessPolicyDefinitionStoreResult = policyDefinitionStore.create(defaultAccessPolicyDefinition);
 
-        if (storeResult.failed() && ALREADY_EXISTS != storeResult.reason()) {
-            throw new IllegalArgumentException(storeResult.getFailureDetail());
+        if (accessPolicyDefinitionStoreResult.failed() && ALREADY_EXISTS != accessPolicyDefinitionStoreResult.reason()) {
+            throw new IllegalArgumentException(accessPolicyDefinitionStoreResult.getFailureDetail());
         }
+
+        var defaultUsagePolicyDefinition = PolicyDefinition.Builder.newInstance()
+                .id(DEFAULT_USAGE_POLICY_DEFINITION_ID)
+                .policy(defaultUsagePolicy)
+                .participantContextId(participantId)
+                .build();
+
+        StoreResult<PolicyDefinition> usagePolicyDefinitionStoreResult = policyDefinitionStore.create(defaultUsagePolicyDefinition);
+
+        if (usagePolicyDefinitionStoreResult.failed() && ALREADY_EXISTS != usagePolicyDefinitionStoreResult.reason()) {
+            throw new IllegalArgumentException(usagePolicyDefinitionStoreResult.getFailureDetail());
+        }
+
     }
 
 
-    private static Policy getPolicy(TypeTransformerRegistry typeTransformerRegistry, Monitor monitor, String participantId, String path) {
+    private static Policy getPolicy(Codec codec, Monitor monitor, String participantId, String path) {
         Policy policy;
         if (path != null) {
-            policy = getPolicyDefinitionFromFile(typeTransformerRegistry, path).orElse(failure -> {
-                monitor.severe(failure.getFailureDetail());
-                return defaultPolicy(participantId);
+            policy = getPolicyFromFile(codec, path).orElse(failure -> {
+                throw new IllegalArgumentException(String.format("Could not parse default policy from %s: %s", path, failure.getFailureDetail()));
             });
         }
         else {
@@ -84,12 +97,12 @@ public abstract class PolicyHelper {
     }
 
 
-    private static Result<Policy> getPolicyDefinitionFromFile(TypeTransformerRegistry typeTransformerRegistry, String filePath) {
+    private static Result<Policy> getPolicyFromFile(Codec codec, String filePath) {
         try {
-            return typeTransformerRegistry.transform(new ObjectMapper().readValue(Path.of(filePath).toFile(), JsonObject.class), Policy.class);
+            return codec.deserialize(Files.readString(Path.of(filePath)), Policy.class);
         }
         catch (IOException ioException) {
-            return Result.failure(String.format("Could not find a valid policy at path %s. Using internal policy as default.", filePath));
+            return Result.failure(ioException.getMessage());
         }
     }
 

--- a/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/handler/aas/AasHandler.java
+++ b/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/app/handler/aas/AasHandler.java
@@ -114,7 +114,9 @@ public abstract class AasHandler<C extends AasServerClient> {
                 .map(StoreResult::getFailureDetail)
                 .toList();
 
-        monitor.warning(String.format("Failed unregistering assets with IDs %s", unregisterFailedMessages));
+        if (unregisterFailedMessages.size() > 0) {
+            monitor.warning(String.format("Failed unregistering assets with IDs %s", unregisterFailedMessages));
+        }
 
         monitor.info(String.format("Unregistered %s AAS elements from repository %s.", filtered.size() - unregisterFailedMessages.size(),
                 client.getUri()));

--- a/extensions/edc-connector-client/src/main/java/de/fraunhofer/iosb/edc/remote/stores/policy/RemotePolicyDefinitionStore.java
+++ b/extensions/edc-connector-client/src/main/java/de/fraunhofer/iosb/edc/remote/stores/policy/RemotePolicyDefinitionStore.java
@@ -60,8 +60,8 @@ public class RemotePolicyDefinitionStore extends ControlPlaneConnectionHandler<P
         // Since you cannot create StoreResult<T> from StoreResult<U>:
         String failureDetail = createResult.getFailureDetail();
         return switch (createResult.reason()) {
-            case NOT_FOUND -> StoreResult.notFound(createResult.getFailureDetail());
-            case ALREADY_EXISTS -> StoreResult.alreadyExists(createResult.getFailureDetail());
+            case NOT_FOUND -> StoreResult.notFound(failureDetail);
+            case ALREADY_EXISTS -> StoreResult.alreadyExists(failureDetail);
             case DUPLICATE_KEYS -> StoreResult.duplicateKeys(failureDetail);
             case ALREADY_LEASED -> StoreResult.alreadyLeased(failureDetail);
             default -> StoreResult.generalError(failureDetail);

--- a/extensions/repository-aas/src/main/java/de/fraunhofer/iosb/model/context/AasServerContext.java
+++ b/extensions/repository-aas/src/main/java/de/fraunhofer/iosb/model/context/AasServerContext.java
@@ -20,7 +20,8 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import java.net.URI;
 import java.util.Objects;
 
-import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_POLICY_DEFINITION_ID;
+import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_ACCESS_POLICY_DEFINITION_ID;
+import static de.fraunhofer.iosb.constants.AasConstants.DEFAULT_USAGE_POLICY_DEFINITION_ID;
 
 
 /**
@@ -90,8 +91,8 @@ public abstract class AasServerContext {
 
 
         protected void validate() {
-            defaultAccessPolicyDefinitionId = Objects.requireNonNullElse(defaultAccessPolicyDefinitionId, DEFAULT_POLICY_DEFINITION_ID);
-            defaultContractPolicyDefinitionId = Objects.requireNonNullElse(defaultContractPolicyDefinitionId, DEFAULT_POLICY_DEFINITION_ID);
+            defaultAccessPolicyDefinitionId = Objects.requireNonNullElse(defaultAccessPolicyDefinitionId, DEFAULT_ACCESS_POLICY_DEFINITION_ID);
+            defaultContractPolicyDefinitionId = Objects.requireNonNullElse(defaultContractPolicyDefinitionId, DEFAULT_USAGE_POLICY_DEFINITION_ID);
         }
     }
 }

--- a/samples/config/standalone.properties
+++ b/samples/config/standalone.properties
@@ -33,3 +33,5 @@ edc.web.rest.cors.enabled=true
 edc.web.rest.cors.origins=*
 edc.web.rest.cors.headers=*
 edc.web.rest.cors.methods=GET, POST, DELETE, PUT, OPTIONS
+
+edc.jsonld.https.enabled=true

--- a/system-tests/resources/contracts.json
+++ b/system-tests/resources/contracts.json
@@ -1,8 +1,6 @@
 [
   {
     "@type": "ContractDefinition",
-    "accessPolicyId": "allow_all",
-    "contractPolicyId": "allow_all",
     "assetsSelector": [
       {
         "@type": "Criterion",

--- a/system-tests/resources/policy.json
+++ b/system-tests/resources/policy.json
@@ -1,6 +1,22 @@
 [
   {
-    "@id": "allow_all",
+    "@type": "PolicyDefinition",
+    "policy": {
+      "@type": "Set",
+      "permission": [
+        {
+          "action": "use"
+        }
+      ],
+      "prohibition": [],
+      "obligation": [],
+      "odrl:assigner": "provider"
+    },
+    "@context": [
+      "https://w3id.org/edc/connector/management/v2"
+    ]
+  },
+  {
     "@type": "PolicyDefinition",
     "policy": {
       "@type": "Set",


### PR DESCRIPTION
## WHAT

Fixes loading of access and usage policy failing.

## WHY

Could not load policies

## FURTHER NOTES

When using the standalone feature, contexts can be dynamically loaded from the `@context` field by supplying the following configuration to the standalone component: `edc.jsonld.https.enabled=true`.

This would e.g., resolve:
```json
 "@context": "https://w3id.org/catenax/2025/9/policy/context.jsonld"
```
to 
```json
{
  "@context": {
    "cx-policy": "https://w3id.org/catenax/2025/9/policy/",
    "odrl": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
    "access": {
      "@id": "cx-policy:access"
    },
    "AffiliatesBpnl": {
      "@id": "cx-policy:AffiliatesBpnl"
    },
    ...
}
```

This does not work for catena-x context however, because when HTTP GETting `https://w3id.org/catenax/2025/9/policy/context.jsonld`, the returned HTTP Header for `content type` is `text/plain` instead of something with `json(ld)`, making EDC's TitaniumJsonLd fail. If catenax policy context terms are required, they either need to be fully qualified:

- `access`->`https://w3id.org/catenax/2025/9/policy/access`

or the following dependency needs to be added to the standalone component:

- `"org.eclipse.tractusx.edc:json-ld-cx:0.12.1"`




Closes #252 