### PR TITLE
fix(ci): do not sign packages

### DIFF
--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew publishMavenPublicationToGithubPackagesRepository --parallel
+        run: ./gradlew publishMavenPublicationToGithubPackagesRepository --parallel -Pskip.signing


### PR DESCRIPTION
## WHAT

Fixes CI error where it tries to sign the package which is not necessary

## WHY

Failing build

## FURTHER NOTES

None