### PR TITLE
fix: allow all DA property types

### DIFF
--- a/extensions/common/aas-lib/src/main/java/de/fraunhofer/iosb/ilt/dataspace/aas/lib/model/PolicyBinding.java
+++ b/extensions/common/aas-lib/src/main/java/de/fraunhofer/iosb/ilt/dataspace/aas/lib/model/PolicyBinding.java
@@ -41,7 +41,7 @@ import static de.fraunhofer.iosb.ilt.dataspace.constants.AasConstants.DEFAULT_US
  */
 public record PolicyBinding(Reference referredElement, @JsonProperty("accessPolicyId") String accessPolicyDefinitionId,
         @JsonProperty("usagePolicyId") String contractPolicyDefinitionId,
-        @JsonProperty("dataAddressProperties") @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, String> dataAddressProperties) {
+        @JsonProperty("dataAddressProperties") @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> dataAddressProperties) {
 
     /**
      * Compact constructor validating and normalizing the record components.

--- a/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/ilt/dataspace/app/aas/mapper/util/AssetIdUtil.java
+++ b/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/ilt/dataspace/app/aas/mapper/util/AssetIdUtil.java
@@ -130,7 +130,7 @@ public abstract class AssetIdUtil {
     private static String bindingSuffix(PolicyBinding policyBinding) {
         String accessPolicyId = String.valueOf(policyBinding.accessPolicyDefinitionId());
         String contractPolicyId = String.valueOf(policyBinding.contractPolicyDefinitionId());
-        Map<String, String> dataAddressProperties = policyBinding.dataAddressProperties();
+        Map<String, Object> dataAddressProperties = policyBinding.dataAddressProperties();
         String dataAddressPart = dataAddressProperties == null ? ""
                 : dataAddressProperties.entrySet().stream()
                         .sorted(Map.Entry.comparingByKey())

--- a/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/ilt/dataspace/app/handler/util/DataAddressMerger.java
+++ b/extensions/control-plane/edc-extension4aas/src/main/java/de/fraunhofer/iosb/ilt/dataspace/app/handler/util/DataAddressMerger.java
@@ -39,7 +39,7 @@ public final class DataAddressMerger {
      * @param override Properties to apply on top of the base (nullable).
      * @return The merged data address.
      */
-    public static DataAddress merge(DataAddress base, Map<String, String> override) {
+    public static DataAddress merge(DataAddress base, Map<String, Object> override) {
         if (override == null || override.isEmpty()) {
             return base;
         }


### PR DESCRIPTION
## WHAT

allow all DA property types

## WHY

For example, proxyBody is a property of type boolean. this is currently not possible

## FURTHER NOTES

None